### PR TITLE
Make the chunk_size configurable

### DIFF
--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -6,20 +6,20 @@ import math
 
 from .hashtable import Hashtable
 
-CHUNK_SIZE = 2**12
+DEFAULT_CHUNK_SIZE = 2**12
 
-def get_chunks(shape, dtype):
+def get_chunks(shape, dtype, chunk_size):
     # TODO: Implement this
     if len(shape) > 1:
         raise NotImplementedError
-    return (CHUNK_SIZE,)
+    return (chunk_size,)
 
-def split_chunks(shape):
+def split_chunks(shape, chunk_size):
     if len(shape) > 1:
         raise NotImplementedError
 
-    for i in range(math.ceil(shape[0]/CHUNK_SIZE)):
-        yield slice(CHUNK_SIZE*i, CHUNK_SIZE*(i + 1))
+    for i in range(math.ceil(shape[0]/chunk_size)):
+        yield slice(chunk_size*i, chunk_size*(i + 1))
 
 def initialize(f):
     version_data = f.create_group('_version_data')
@@ -27,19 +27,28 @@ def initialize(f):
     versions.create_group('__first_version__')
     versions.attrs['current_version'] = '__first_version__'
 
-def create_base_dataset(f, name, *, shape=None, data=None, dtype=np.float64):
+def create_base_dataset(f, name, *, shape=None, data=None, dtype=np.float64,
+    chunk_size=None):
+    chunk_size = chunk_size or DEFAULT_CHUNK_SIZE
     group = f['/_version_data'].create_group(name)
-    group.create_dataset('raw_data', shape=(0,), chunks=(CHUNK_SIZE,),
+    dataset = group.create_dataset('raw_data', shape=(0,), chunks=(chunk_size,),
                          maxshape=(None,), dtype=dtype)
-    return write_dataset(f, name, data)
+    dataset.attrs['chunk_size'] = chunk_size
+    return write_dataset(f, name, data, chunk_size=chunk_size)
 
-def write_dataset(f, name, data):
+def write_dataset(f, name, data, chunk_size=None):
     from .slicetools import s2t, t2s
 
     if name not in f['/_version_data']:
-        return create_base_dataset(f, name, data=data)
+        return create_base_dataset(f, name, data=data, chunk_size=chunk_size)
 
     ds = f['/_version_data'][name]['raw_data']
+    if chunk_size is None:
+        chunk_size = ds.attrs['chunk_size']
+    else:
+        if chunk_size != ds.attrs['chunk_size']:
+            raise ValueError("Chunk size specified but doesn't match already existing chunk size")
+
     if data.dtype != ds.dtype:
         raise ValueError(f"dtypes do not match ({data.dtype} != {ds.dtype})")
     # TODO: Handle more than one dimension
@@ -47,17 +56,17 @@ def write_dataset(f, name, data):
     hashtable = Hashtable(f, name)
     slices = []
     slices_to_write = {}
-    for s in split_chunks(data.shape):
+    for s in split_chunks(data.shape, chunk_size):
         idx = hashtable.largest_index
         data_s = data[s]
-        raw_slice = slice(idx*CHUNK_SIZE, idx*CHUNK_SIZE + data_s.shape[0])
+        raw_slice = slice(idx*chunk_size, idx*chunk_size + data_s.shape[0])
         data_hash = hashtable.hash(data_s)
         raw_slice2 = hashtable.setdefault(data_hash, raw_slice)
         if raw_slice2 == raw_slice:
             slices_to_write[s2t(raw_slice)] = s
         slices.append(raw_slice2)
 
-    ds.resize((old_shape[0] + len(slices_to_write)*CHUNK_SIZE,))
+    ds.resize((old_shape[0] + len(slices_to_write)*chunk_size,))
     for raw_slice, s in slices_to_write.items():
         ds[t2s(raw_slice)] = data[s]
     return slices
@@ -74,6 +83,7 @@ def write_dataset_chunks(f, name, data_dict):
         raise NotImplementedError("Use write_dataset() if the dataset does not yet exist")
 
     ds = f['/_version_data'][name]['raw_data']
+    chunk_size = ds.attrs['chunk_size']
     # TODO: Handle more than one dimension
     nchunks = max(data_dict)
     if any(i not in data_dict for i in range(nchunks)):
@@ -90,7 +100,7 @@ def write_dataset_chunks(f, name, data_dict):
         if isinstance(data_s, (slice, tuple)):
             slices[chunk] = data_s
         else:
-            raw_slice = slice(idx*CHUNK_SIZE, idx*CHUNK_SIZE + data_s.shape[0])
+            raw_slice = slice(idx*chunk_size, idx*chunk_size + data_s.shape[0])
             data_hash = hashtable.hash(data_s)
             raw_slice2 = hashtable.setdefault(data_hash, raw_slice)
             if raw_slice2 == raw_slice:
@@ -99,24 +109,25 @@ def write_dataset_chunks(f, name, data_dict):
 
     assert None not in slices
     old_shape = ds.shape
-    ds.resize((old_shape[0] + len(data_to_write)*CHUNK_SIZE,))
+    ds.resize((old_shape[0] + len(data_to_write)*chunk_size,))
     for raw_slice, data_s in data_to_write.items():
         ds[t2s(raw_slice)] = data_s
     return slices
 
 def create_virtual_dataset(f, version_name, name, slices):
-    for s in slices[:-1]:
-        if s.stop - s.start != CHUNK_SIZE:
-            raise NotImplementedError("Smaller than chunk size slice is only supported as the last slice.")
-    shape = (CHUNK_SIZE*(len(slices) - 1) + slices[-1].stop - slices[-1].start,)
-
     raw_data = f['_version_data'][name]['raw_data']
+    chunk_size = raw_data.attrs['chunk_size']
+    for s in slices[:-1]:
+        if s.stop - s.start != chunk_size:
+            raise NotImplementedError("Smaller than chunk size slice is only supported as the last slice.")
+    shape = (chunk_size*(len(slices) - 1) + slices[-1].stop - slices[-1].start,)
+
     layout = VirtualLayout(shape, dtype=raw_data.dtype)
     vs = VirtualSource(raw_data)
 
     for i, s in enumerate(slices):
         # TODO: This needs to handle more than one dimension
-        layout[i*CHUNK_SIZE:i*CHUNK_SIZE + s.stop - s.start] = vs[s]
+        layout[i*chunk_size:i*chunk_size + s.stop - s.start] = vs[s]
 
     virtual_data = f['_version_data/versions'][version_name].create_virtual_dataset(name, layout)
     return virtual_data

--- a/versioned_hdf5/slicetools.py
+++ b/versioned_hdf5/slicetools.py
@@ -1,7 +1,5 @@
 import math
 
-from .backend import CHUNK_SIZE
-
 # Helper functions to workaround slices not being hashable
 def s2t(s):
     if isinstance(s, tuple):
@@ -13,7 +11,7 @@ def t2s(t):
         return tuple(slice(*i) for i in t)
     return slice(*t)
 
-def split_slice(s, chunk=CHUNK_SIZE):
+def split_slice(s, chunk):
     """
     Split a slice into multiple slices along 0:chunk, chunk:2*chunk, etc.
 

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_equal
 
 from h5py._hl.selections import Selection
 
-from ..backend import CHUNK_SIZE
+from ..backend import DEFAULT_CHUNK_SIZE
 from ..api import VersionedHDF5File, spaceid_to_slice
 
 from .test_backend import setup
@@ -14,9 +14,9 @@ def test_stage_version():
     with setup() as f:
         file = VersionedHDF5File(f)
 
-        test_data = np.concatenate((np.ones((2*CHUNK_SIZE,)),
-                                    2*np.ones((CHUNK_SIZE,)),
-                                    3*np.ones((CHUNK_SIZE,))))
+        test_data = np.concatenate((np.ones((2*DEFAULT_CHUNK_SIZE,)),
+                                    2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                                    3*np.ones((DEFAULT_CHUNK_SIZE,))))
 
 
         with file.stage_version('version1', '') as group:
@@ -28,10 +28,10 @@ def test_stage_version():
 
         ds = f['/_version_data/test_data/raw_data']
 
-        assert ds.shape == (3*CHUNK_SIZE,)
-        assert_equal(ds[0:1*CHUNK_SIZE], 1.0)
-        assert_equal(ds[1*CHUNK_SIZE:2*CHUNK_SIZE], 2.0)
-        assert_equal(ds[2*CHUNK_SIZE:3*CHUNK_SIZE], 3.0)
+        assert ds.shape == (3*DEFAULT_CHUNK_SIZE,)
+        assert_equal(ds[0:1*DEFAULT_CHUNK_SIZE], 1.0)
+        assert_equal(ds[1*DEFAULT_CHUNK_SIZE:2*DEFAULT_CHUNK_SIZE], 2.0)
+        assert_equal(ds[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE], 3.0)
 
         with file.stage_version('version2', 'version1') as group:
             group['test_data'][0] = 0.0
@@ -41,19 +41,19 @@ def test_stage_version():
         test_data[0] = 0.0
         assert_equal(version2['test_data'], test_data)
 
-        assert ds.shape == (4*CHUNK_SIZE,)
-        assert_equal(ds[0:1*CHUNK_SIZE], 1.0)
-        assert_equal(ds[1*CHUNK_SIZE:2*CHUNK_SIZE], 2.0)
-        assert_equal(ds[2*CHUNK_SIZE:3*CHUNK_SIZE], 3.0)
-        assert_equal(ds[3*CHUNK_SIZE], 0.0)
-        assert_equal(ds[3*CHUNK_SIZE+1:4*CHUNK_SIZE], 1.0)
+        assert ds.shape == (4*DEFAULT_CHUNK_SIZE,)
+        assert_equal(ds[0:1*DEFAULT_CHUNK_SIZE], 1.0)
+        assert_equal(ds[1*DEFAULT_CHUNK_SIZE:2*DEFAULT_CHUNK_SIZE], 2.0)
+        assert_equal(ds[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE], 3.0)
+        assert_equal(ds[3*DEFAULT_CHUNK_SIZE], 0.0)
+        assert_equal(ds[3*DEFAULT_CHUNK_SIZE+1:4*DEFAULT_CHUNK_SIZE], 1.0)
 
 def test_version_int_slicing():
     with setup() as f:
         file = VersionedHDF5File(f)
-        test_data = np.concatenate((np.ones((2*CHUNK_SIZE,)),
-                               2*np.ones((CHUNK_SIZE,)),
-                               3*np.ones((CHUNK_SIZE,))))
+        test_data = np.concatenate((np.ones((2*DEFAULT_CHUNK_SIZE,)),
+                               2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                               3*np.ones((DEFAULT_CHUNK_SIZE,))))
 
         with file.stage_version('version1', '') as group:
             group['test_data'] = test_data
@@ -104,9 +104,9 @@ def test_version_int_slicing():
 def test_version_name_slicing():
     with setup() as f:
         file = VersionedHDF5File(f)
-        test_data = np.concatenate((np.ones((2*CHUNK_SIZE,)),
-                               2*np.ones((CHUNK_SIZE,)),
-                               3*np.ones((CHUNK_SIZE,))))
+        test_data = np.concatenate((np.ones((2*DEFAULT_CHUNK_SIZE,)),
+                               2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                               3*np.ones((DEFAULT_CHUNK_SIZE,))))
 
         with file.stage_version('version1', '') as group:
             group['test_data'] = test_data
@@ -132,9 +132,9 @@ def test_version_name_slicing():
 def test_iter_versions():
     with setup() as f:
         file = VersionedHDF5File(f)
-        test_data = np.concatenate((np.ones((2*CHUNK_SIZE,)),
-                               2*np.ones((CHUNK_SIZE,)),
-                               3*np.ones((CHUNK_SIZE,))))
+        test_data = np.concatenate((np.ones((2*DEFAULT_CHUNK_SIZE,)),
+                               2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                               3*np.ones((DEFAULT_CHUNK_SIZE,))))
 
         with file.stage_version('version1', '') as group:
             group['test_data'] = test_data
@@ -154,9 +154,9 @@ def test_create_dataset():
         file = VersionedHDF5File(f)
 
 
-        test_data = np.concatenate((np.ones((2*CHUNK_SIZE,)),
-                                    2*np.ones((CHUNK_SIZE,)),
-                                    3*np.ones((CHUNK_SIZE,))))
+        test_data = np.concatenate((np.ones((2*DEFAULT_CHUNK_SIZE,)),
+                                    2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                                    3*np.ones((DEFAULT_CHUNK_SIZE,))))
 
 
         with file.stage_version('version1', '') as group:
@@ -168,18 +168,18 @@ def test_create_dataset():
 
         ds = f['/_version_data/test_data/raw_data']
 
-        assert ds.shape == (3*CHUNK_SIZE,)
-        assert_equal(ds[0:1*CHUNK_SIZE], 1.0)
-        assert_equal(ds[1*CHUNK_SIZE:2*CHUNK_SIZE], 2.0)
-        assert_equal(ds[2*CHUNK_SIZE:3*CHUNK_SIZE], 3.0)
+        assert ds.shape == (3*DEFAULT_CHUNK_SIZE,)
+        assert_equal(ds[0:1*DEFAULT_CHUNK_SIZE], 1.0)
+        assert_equal(ds[1*DEFAULT_CHUNK_SIZE:2*DEFAULT_CHUNK_SIZE], 2.0)
+        assert_equal(ds[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE], 3.0)
 
 def test_unmodified():
     with setup() as f:
         file = VersionedHDF5File(f)
 
-        test_data = np.concatenate((np.ones((2*CHUNK_SIZE,)),
-                                    2*np.ones((CHUNK_SIZE,)),
-                                    3*np.ones((CHUNK_SIZE,))))
+        test_data = np.concatenate((np.ones((2*DEFAULT_CHUNK_SIZE,)),
+                                    2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                                    3*np.ones((DEFAULT_CHUNK_SIZE,))))
 
         with file.stage_version('version1') as group:
             group.create_dataset('test_data', data=test_data)
@@ -204,9 +204,9 @@ def test_delete():
     with setup() as f:
         file = VersionedHDF5File(f)
 
-        test_data = np.concatenate((np.ones((2*CHUNK_SIZE,)),
-                                    2*np.ones((CHUNK_SIZE,)),
-                                    3*np.ones((CHUNK_SIZE,))))
+        test_data = np.concatenate((np.ones((2*DEFAULT_CHUNK_SIZE,)),
+                                    2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                                    3*np.ones((DEFAULT_CHUNK_SIZE,))))
 
         with file.stage_version('version1') as group:
             group.create_dataset('test_data', data=test_data)

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -48,6 +48,49 @@ def test_stage_version():
         assert_equal(ds[3*DEFAULT_CHUNK_SIZE], 0.0)
         assert_equal(ds[3*DEFAULT_CHUNK_SIZE+1:4*DEFAULT_CHUNK_SIZE], 1.0)
 
+def test_stage_version_chunk_size():
+    with setup() as f:
+        chunk_size = 2**10
+        file = VersionedHDF5File(f)
+
+        test_data = np.concatenate((np.ones((2*chunk_size,)),
+                                    2*np.ones((chunk_size,)),
+                                    3*np.ones((chunk_size,))))
+
+
+        with file.stage_version('version1', '', chunk_size=chunk_size) as group:
+            group['test_data'] = test_data
+
+        with raises(ValueError):
+            with file.stage_version('version_bad', chunk_size=2**9) as group:
+                group['test_data'] = test_data
+
+        version1 = file['version1']
+        assert version1.attrs['prev_version'] == '__first_version__'
+        assert_equal(version1['test_data'], test_data)
+
+        ds = f['/_version_data/test_data/raw_data']
+
+        assert ds.shape == (3*chunk_size,)
+        assert_equal(ds[0:1*chunk_size], 1.0)
+        assert_equal(ds[1*chunk_size:2*chunk_size], 2.0)
+        assert_equal(ds[2*chunk_size:3*chunk_size], 3.0)
+
+        with file.stage_version('version2', 'version1') as group:
+            group['test_data'][0] = 0.0
+
+        version2 = file['version2']
+        assert version2.attrs['prev_version'] == 'version1'
+        test_data[0] = 0.0
+        assert_equal(version2['test_data'], test_data)
+
+        assert ds.shape == (4*chunk_size,)
+        assert_equal(ds[0:1*chunk_size], 1.0)
+        assert_equal(ds[1*chunk_size:2*chunk_size], 2.0)
+        assert_equal(ds[2*chunk_size:3*chunk_size], 3.0)
+        assert_equal(ds[3*chunk_size], 0.0)
+        assert_equal(ds[3*chunk_size+1:4*chunk_size], 1.0)
+
 def test_version_int_slicing():
     with setup() as f:
         file = VersionedHDF5File(f)

--- a/versioned_hdf5/tests/test_backend.py
+++ b/versioned_hdf5/tests/test_backend.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_equal
 
 from ..backend import (create_base_dataset, initialize, write_dataset,
-                       create_virtual_dataset, CHUNK_SIZE,
+                       create_virtual_dataset, DEFAULT_CHUNK_SIZE,
                        write_dataset_chunks)
 
 def setup(name=None, version_name=None):
@@ -22,104 +22,104 @@ def test_initialize():
 
 def test_create_base_dataset():
     with setup() as f:
-        create_base_dataset(f, 'test_data', data=np.ones((CHUNK_SIZE,)))
+        create_base_dataset(f, 'test_data', data=np.ones((DEFAULT_CHUNK_SIZE,)))
         assert f['_version_data/test_data/raw_data'].dtype == np.float64
 
 def test_write_dataset():
     with setup() as f:
-        slices1 = write_dataset(f, 'test_data', np.ones((2*CHUNK_SIZE,)))
+        slices1 = write_dataset(f, 'test_data', np.ones((2*DEFAULT_CHUNK_SIZE,)))
         slices2 = write_dataset(f, 'test_data',
-                                np.concatenate((2*np.ones((CHUNK_SIZE,)),
-                                                2*np.ones((CHUNK_SIZE,)),
-                                                3*np.ones((CHUNK_SIZE,)),
+                                np.concatenate((2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                                                2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                                                3*np.ones((DEFAULT_CHUNK_SIZE,)),
                                 )))
 
-        assert slices1 == [slice(0*CHUNK_SIZE, 1*CHUNK_SIZE),
-                           slice(0*CHUNK_SIZE, 1*CHUNK_SIZE)]
-        assert slices2 == [slice(1*CHUNK_SIZE, 2*CHUNK_SIZE),
-                           slice(1*CHUNK_SIZE, 2*CHUNK_SIZE),
-                           slice(2*CHUNK_SIZE, 3*CHUNK_SIZE)]
+        assert slices1 == [slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE),
+                           slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE)]
+        assert slices2 == [slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE),
+                           slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE),
+                           slice(2*DEFAULT_CHUNK_SIZE, 3*DEFAULT_CHUNK_SIZE)]
 
         ds = f['/_version_data/test_data/raw_data']
-        assert ds.shape == (3*CHUNK_SIZE,)
-        assert_equal(ds[0:1*CHUNK_SIZE], 1.0)
-        assert_equal(ds[1*CHUNK_SIZE:2*CHUNK_SIZE], 2.0)
-        assert_equal(ds[2*CHUNK_SIZE:3*CHUNK_SIZE], 3.0)
-        assert_equal(ds[3*CHUNK_SIZE:4*CHUNK_SIZE], 0.0)
+        assert ds.shape == (3*DEFAULT_CHUNK_SIZE,)
+        assert_equal(ds[0:1*DEFAULT_CHUNK_SIZE], 1.0)
+        assert_equal(ds[1*DEFAULT_CHUNK_SIZE:2*DEFAULT_CHUNK_SIZE], 2.0)
+        assert_equal(ds[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE], 3.0)
+        assert_equal(ds[3*DEFAULT_CHUNK_SIZE:4*DEFAULT_CHUNK_SIZE], 0.0)
         assert ds.dtype == np.float64
 
 def test_write_dataset_chunks():
     with setup() as f:
-        slices1 = write_dataset(f, 'test_data', np.ones((2*CHUNK_SIZE,)))
+        slices1 = write_dataset(f, 'test_data', np.ones((2*DEFAULT_CHUNK_SIZE,)))
         slices2 = write_dataset_chunks(f, 'test_data',
                                        {0: slices1[0],
-                                        1: 2*np.ones((CHUNK_SIZE,)),
-                                        2: 2*np.ones((CHUNK_SIZE,)),
-                                        3: 3*np.ones((CHUNK_SIZE,)),
+                                        1: 2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                                        2: 2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                                        3: 3*np.ones((DEFAULT_CHUNK_SIZE,)),
                                        })
 
-        assert slices1 == [slice(0*CHUNK_SIZE, 1*CHUNK_SIZE),
-                           slice(0*CHUNK_SIZE, 1*CHUNK_SIZE)]
-        assert slices2 == [slice(0*CHUNK_SIZE, 1*CHUNK_SIZE),
-                           slice(1*CHUNK_SIZE, 2*CHUNK_SIZE),
-                           slice(1*CHUNK_SIZE, 2*CHUNK_SIZE),
-                           slice(2*CHUNK_SIZE, 3*CHUNK_SIZE)]
+        assert slices1 == [slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE),
+                           slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE)]
+        assert slices2 == [slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE),
+                           slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE),
+                           slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE),
+                           slice(2*DEFAULT_CHUNK_SIZE, 3*DEFAULT_CHUNK_SIZE)]
 
         ds = f['/_version_data/test_data/raw_data']
-        assert ds.shape == (3*CHUNK_SIZE,)
-        assert_equal(ds[0:1*CHUNK_SIZE], 1.0)
-        assert_equal(ds[1*CHUNK_SIZE:2*CHUNK_SIZE], 2.0)
-        assert_equal(ds[2*CHUNK_SIZE:3*CHUNK_SIZE], 3.0)
-        assert_equal(ds[3*CHUNK_SIZE:4*CHUNK_SIZE], 0.0)
+        assert ds.shape == (3*DEFAULT_CHUNK_SIZE,)
+        assert_equal(ds[0:1*DEFAULT_CHUNK_SIZE], 1.0)
+        assert_equal(ds[1*DEFAULT_CHUNK_SIZE:2*DEFAULT_CHUNK_SIZE], 2.0)
+        assert_equal(ds[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE], 3.0)
+        assert_equal(ds[3*DEFAULT_CHUNK_SIZE:4*DEFAULT_CHUNK_SIZE], 0.0)
         assert ds.dtype == np.float64
 
 
 def test_write_dataset_offset():
     with setup() as f:
-        slices1 = write_dataset(f, 'test_data', np.ones((2*CHUNK_SIZE,)))
+        slices1 = write_dataset(f, 'test_data', np.ones((2*DEFAULT_CHUNK_SIZE,)))
         slices2 = write_dataset(f, 'test_data',
-                                np.concatenate((2*np.ones((CHUNK_SIZE,)),
-                                                2*np.ones((CHUNK_SIZE,)),
-                                                3*np.ones((CHUNK_SIZE - 2,)))))
+                                np.concatenate((2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                                                2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                                                3*np.ones((DEFAULT_CHUNK_SIZE - 2,)))))
 
-        assert slices1 == [slice(0*CHUNK_SIZE, 1*CHUNK_SIZE),
-                           slice(0*CHUNK_SIZE, 1*CHUNK_SIZE)]
-        assert slices2 == [slice(1*CHUNK_SIZE, 2*CHUNK_SIZE),
-                           slice(1*CHUNK_SIZE, 2*CHUNK_SIZE),
-                           slice(2*CHUNK_SIZE, 3*CHUNK_SIZE - 2)]
+        assert slices1 == [slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE),
+                           slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE)]
+        assert slices2 == [slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE),
+                           slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE),
+                           slice(2*DEFAULT_CHUNK_SIZE, 3*DEFAULT_CHUNK_SIZE - 2)]
 
         ds = f['/_version_data/test_data/raw_data']
-        assert ds.shape == (3*CHUNK_SIZE,)
-        assert_equal(ds[0*CHUNK_SIZE:1*CHUNK_SIZE], 1.0)
-        assert_equal(ds[1*CHUNK_SIZE:2*CHUNK_SIZE], 2.0)
-        assert_equal(ds[2*CHUNK_SIZE:3*CHUNK_SIZE - 2], 3.0)
-        assert_equal(ds[3*CHUNK_SIZE-2:4*CHUNK_SIZE], 0.0)
+        assert ds.shape == (3*DEFAULT_CHUNK_SIZE,)
+        assert_equal(ds[0*DEFAULT_CHUNK_SIZE:1*DEFAULT_CHUNK_SIZE], 1.0)
+        assert_equal(ds[1*DEFAULT_CHUNK_SIZE:2*DEFAULT_CHUNK_SIZE], 2.0)
+        assert_equal(ds[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE - 2], 3.0)
+        assert_equal(ds[3*DEFAULT_CHUNK_SIZE-2:4*DEFAULT_CHUNK_SIZE], 0.0)
 
 def test_create_virtual_dataset():
     with setup(version_name='test_version') as f:
-        slices1 = write_dataset(f, 'test_data', np.ones((2*CHUNK_SIZE,)))
+        slices1 = write_dataset(f, 'test_data', np.ones((2*DEFAULT_CHUNK_SIZE,)))
         slices2 = write_dataset(f, 'test_data',
-                                np.concatenate((2*np.ones((CHUNK_SIZE,)),
-                                                3*np.ones((CHUNK_SIZE,)))))
+                                np.concatenate((2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                                                3*np.ones((DEFAULT_CHUNK_SIZE,)))))
 
         virtual_data = create_virtual_dataset(f, 'test_version', 'test_data',
                                               slices1 + [slices2[1]])
 
-        assert virtual_data.shape == (3*CHUNK_SIZE,)
-        assert_equal(virtual_data[0:2*CHUNK_SIZE], 1.0)
-        assert_equal(virtual_data[2*CHUNK_SIZE:3*CHUNK_SIZE], 3.0)
+        assert virtual_data.shape == (3*DEFAULT_CHUNK_SIZE,)
+        assert_equal(virtual_data[0:2*DEFAULT_CHUNK_SIZE], 1.0)
+        assert_equal(virtual_data[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE], 3.0)
         assert virtual_data.dtype == np.float64
 
 def test_create_virtual_dataset_offset():
     with setup(version_name='test_version') as f:
-        slices1 = write_dataset(f, 'test_data', np.ones((2*CHUNK_SIZE,)))
+        slices1 = write_dataset(f, 'test_data', np.ones((2*DEFAULT_CHUNK_SIZE,)))
         slices2 = write_dataset(f, 'test_data',
-                                np.concatenate((2*np.ones((CHUNK_SIZE,)),
-                                                3*np.ones((CHUNK_SIZE - 2,)))))
+                                np.concatenate((2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                                                3*np.ones((DEFAULT_CHUNK_SIZE - 2,)))))
 
         virtual_data = create_virtual_dataset(f, 'test_version', 'test_data',
                                               slices1 + [slices2[1]])
 
-        assert virtual_data.shape == (3*CHUNK_SIZE - 2,)
-        assert_equal(virtual_data[0:2*CHUNK_SIZE], 1.0)
-        assert_equal(virtual_data[2*CHUNK_SIZE:3*CHUNK_SIZE - 2], 3.0)
+        assert virtual_data.shape == (3*DEFAULT_CHUNK_SIZE - 2,)
+        assert_equal(virtual_data[0:2*DEFAULT_CHUNK_SIZE], 1.0)
+        assert_equal(virtual_data[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE - 2], 3.0)

--- a/versioned_hdf5/tests/test_backend.py
+++ b/versioned_hdf5/tests/test_backend.py
@@ -3,6 +3,8 @@ import h5py
 import numpy as np
 from numpy.testing import assert_equal
 
+from pytest import raises
+
 from ..backend import (create_base_dataset, initialize, write_dataset,
                        create_virtual_dataset, DEFAULT_CHUNK_SIZE,
                        write_dataset_chunks)
@@ -123,3 +125,56 @@ def test_create_virtual_dataset_offset():
         assert virtual_data.shape == (3*DEFAULT_CHUNK_SIZE - 2,)
         assert_equal(virtual_data[0:2*DEFAULT_CHUNK_SIZE], 1.0)
         assert_equal(virtual_data[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE - 2], 3.0)
+
+
+def test_write_dataset_chunk_size():
+    with setup() as f:
+        chunk_size = 2**10
+        slices1 = write_dataset(f, 'test_data', np.ones((2*chunk_size,)),
+                                chunk_size=chunk_size)
+        raises(ValueError, lambda: write_dataset(f, 'test_data',
+            np.ones((chunk_size,)), chunk_size=2**9))
+        slices2 = write_dataset_chunks(f, 'test_data',
+                                       {0: slices1[0],
+                                        1: 2*np.ones((chunk_size,)),
+                                        2: 2*np.ones((chunk_size,)),
+                                        3: 3*np.ones((chunk_size,)),
+                                       })
+
+        assert slices1 == [slice(0*chunk_size, 1*chunk_size),
+                           slice(0*chunk_size, 1*chunk_size)]
+        assert slices2 == [slice(0*chunk_size, 1*chunk_size),
+                           slice(1*chunk_size, 2*chunk_size),
+                           slice(1*chunk_size, 2*chunk_size),
+                           slice(2*chunk_size, 3*chunk_size)]
+
+        ds = f['/_version_data/test_data/raw_data']
+        assert ds.shape == (3*chunk_size,)
+        assert_equal(ds[0:1*chunk_size], 1.0)
+        assert_equal(ds[1*chunk_size:2*chunk_size], 2.0)
+        assert_equal(ds[2*chunk_size:3*chunk_size], 3.0)
+        assert_equal(ds[3*chunk_size:4*chunk_size], 0.0)
+        assert ds.dtype == np.float64
+
+
+def test_write_dataset_offset_chunk_size():
+    with setup() as f:
+        chunk_size = 2**10
+        slices1 = write_dataset(f, 'test_data', np.ones((2*chunk_size,)), chunk_size=chunk_size)
+        slices2 = write_dataset(f, 'test_data',
+                                np.concatenate((2*np.ones((chunk_size,)),
+                                                2*np.ones((chunk_size,)),
+                                                3*np.ones((chunk_size - 2,)))))
+
+        assert slices1 == [slice(0*chunk_size, 1*chunk_size),
+                           slice(0*chunk_size, 1*chunk_size)]
+        assert slices2 == [slice(1*chunk_size, 2*chunk_size),
+                           slice(1*chunk_size, 2*chunk_size),
+                           slice(2*chunk_size, 3*chunk_size - 2)]
+
+        ds = f['/_version_data/test_data/raw_data']
+        assert ds.shape == (3*chunk_size,)
+        assert_equal(ds[0*chunk_size:1*chunk_size], 1.0)
+        assert_equal(ds[1*chunk_size:2*chunk_size], 2.0)
+        assert_equal(ds[2*chunk_size:3*chunk_size - 2], 3.0)
+        assert_equal(ds[3*chunk_size-2:4*chunk_size], 0.0)

--- a/versioned_hdf5/tests/test_hashtable.py
+++ b/versioned_hdf5/tests/test_hashtable.py
@@ -1,11 +1,15 @@
 from pytest import raises
 
+import numpy as np
+
+from ..backend import create_base_dataset
 from ..hashtable import Hashtable
 
 from .test_backend import setup
 
 def test_hashtable():
-    with setup('test_data') as f:
+    with setup() as f:
+        create_base_dataset(f, 'test_data', data=np.empty((0,)))
         h = Hashtable(f, 'test_data')
         assert len(h) == 0
         h[b'\xff'*32] = slice(0, 1)

--- a/versioned_hdf5/tests/test_versions.py
+++ b/versioned_hdf5/tests/test_versions.py
@@ -5,15 +5,15 @@ from numpy.testing import assert_equal
 
 from .test_backend import setup
 
-from ..backend import CHUNK_SIZE
+from ..backend import DEFAULT_CHUNK_SIZE
 from ..versions import (create_version, get_nth_previous_version,
                         set_current_version, all_versions)
 
 def test_create_version():
     with setup() as f:
-        data = np.concatenate((np.ones((2*CHUNK_SIZE,)),
-                               2*np.ones((CHUNK_SIZE,)),
-                               3*np.ones((CHUNK_SIZE,))))
+        data = np.concatenate((np.ones((2*DEFAULT_CHUNK_SIZE,)),
+                               2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                               3*np.ones((DEFAULT_CHUNK_SIZE,))))
 
         version1 = create_version(f, 'version1', {'test_data': data}, '')
         assert version1.attrs['prev_version'] == '__first_version__'
@@ -22,10 +22,10 @@ def test_create_version():
 
         ds = f['/_version_data/test_data/raw_data']
 
-        assert ds.shape == (3*CHUNK_SIZE,)
-        assert_equal(ds[0:1*CHUNK_SIZE], 1.0)
-        assert_equal(ds[1*CHUNK_SIZE:2*CHUNK_SIZE], 2.0)
-        assert_equal(ds[2*CHUNK_SIZE:3*CHUNK_SIZE], 3.0)
+        assert ds.shape == (3*DEFAULT_CHUNK_SIZE,)
+        assert_equal(ds[0:1*DEFAULT_CHUNK_SIZE], 1.0)
+        assert_equal(ds[1*DEFAULT_CHUNK_SIZE:2*DEFAULT_CHUNK_SIZE], 2.0)
+        assert_equal(ds[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE], 3.0)
 
         data[0] = 0.0
         version2 = create_version(f, 'version2', {'test_data':
@@ -34,12 +34,12 @@ def test_create_version():
         assert_equal(version2['test_data'], data)
         assert version2.parent.attrs['current_version'] == 'version1'
 
-        assert ds.shape == (4*CHUNK_SIZE,)
-        assert_equal(ds[0:1*CHUNK_SIZE], 1.0)
-        assert_equal(ds[1*CHUNK_SIZE:2*CHUNK_SIZE], 2.0)
-        assert_equal(ds[2*CHUNK_SIZE:3*CHUNK_SIZE], 3.0)
-        assert_equal(ds[3*CHUNK_SIZE], 0.0)
-        assert_equal(ds[3*CHUNK_SIZE+1:4*CHUNK_SIZE], 1.0)
+        assert ds.shape == (4*DEFAULT_CHUNK_SIZE,)
+        assert_equal(ds[0:1*DEFAULT_CHUNK_SIZE], 1.0)
+        assert_equal(ds[1*DEFAULT_CHUNK_SIZE:2*DEFAULT_CHUNK_SIZE], 2.0)
+        assert_equal(ds[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE], 3.0)
+        assert_equal(ds[3*DEFAULT_CHUNK_SIZE], 0.0)
+        assert_equal(ds[3*DEFAULT_CHUNK_SIZE+1:4*DEFAULT_CHUNK_SIZE], 1.0)
 
         assert set(all_versions(f)) == {'version1', 'version2'}
         assert set(all_versions(f, include_first=True)) == {'version1',
@@ -48,24 +48,24 @@ def test_create_version():
 
 def test_create_version_chunks():
     with setup() as f:
-        data = np.concatenate((np.ones((2*CHUNK_SIZE,)),
-                               2*np.ones((CHUNK_SIZE,)),
-                               3*np.ones((CHUNK_SIZE,))))
+        data = np.concatenate((np.ones((2*DEFAULT_CHUNK_SIZE,)),
+                               2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                               3*np.ones((DEFAULT_CHUNK_SIZE,))))
         # TODO: Support creating the initial version with chunks
         version1 = create_version(f, 'version1', {'test_data': data})
         assert_equal(version1['test_data'], data)
 
         ds = f['/_version_data/test_data/raw_data']
 
-        assert ds.shape == (3*CHUNK_SIZE,)
-        assert_equal(ds[0:1*CHUNK_SIZE], 1.0)
-        assert_equal(ds[1*CHUNK_SIZE:2*CHUNK_SIZE], 2.0)
-        assert_equal(ds[2*CHUNK_SIZE:3*CHUNK_SIZE], 3.0)
+        assert ds.shape == (3*DEFAULT_CHUNK_SIZE,)
+        assert_equal(ds[0:1*DEFAULT_CHUNK_SIZE], 1.0)
+        assert_equal(ds[1*DEFAULT_CHUNK_SIZE:2*DEFAULT_CHUNK_SIZE], 2.0)
+        assert_equal(ds[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE], 3.0)
 
-        data2_chunks = {0: np.ones((CHUNK_SIZE,)),
-                        1: np.ones((CHUNK_SIZE,)),
-                        2: 2*np.ones((CHUNK_SIZE,)),
-                        3: 3*np.ones((CHUNK_SIZE,)),
+        data2_chunks = {0: np.ones((DEFAULT_CHUNK_SIZE,)),
+                        1: np.ones((DEFAULT_CHUNK_SIZE,)),
+                        2: 2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                        3: 3*np.ones((DEFAULT_CHUNK_SIZE,)),
         }
         data2_chunks[0][0] = 0.0
         data[0] = 0.0
@@ -73,18 +73,18 @@ def test_create_version_chunks():
         version2 = create_version(f, 'version2', {'test_data':  data2_chunks})
         assert_equal(version2['test_data'], data)
 
-        assert ds.shape == (4*CHUNK_SIZE,)
-        assert_equal(ds[0:1*CHUNK_SIZE], 1.0)
-        assert_equal(ds[1*CHUNK_SIZE:2*CHUNK_SIZE], 2.0)
-        assert_equal(ds[2*CHUNK_SIZE:3*CHUNK_SIZE], 3.0)
-        assert_equal(ds[3*CHUNK_SIZE], 0.0)
-        assert_equal(ds[3*CHUNK_SIZE+1:4*CHUNK_SIZE], 1.0)
+        assert ds.shape == (4*DEFAULT_CHUNK_SIZE,)
+        assert_equal(ds[0:1*DEFAULT_CHUNK_SIZE], 1.0)
+        assert_equal(ds[1*DEFAULT_CHUNK_SIZE:2*DEFAULT_CHUNK_SIZE], 2.0)
+        assert_equal(ds[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE], 3.0)
+        assert_equal(ds[3*DEFAULT_CHUNK_SIZE], 0.0)
+        assert_equal(ds[3*DEFAULT_CHUNK_SIZE+1:4*DEFAULT_CHUNK_SIZE], 1.0)
 
 
-        data3_chunks = {0: np.ones((CHUNK_SIZE,)),
-                        1: slice(0*CHUNK_SIZE, 1*CHUNK_SIZE),
-                        2: slice(1*CHUNK_SIZE, 2*CHUNK_SIZE),
-                        3: slice(2*CHUNK_SIZE, 3*CHUNK_SIZE),
+        data3_chunks = {0: np.ones((DEFAULT_CHUNK_SIZE,)),
+                        1: slice(0*DEFAULT_CHUNK_SIZE, 1*DEFAULT_CHUNK_SIZE),
+                        2: slice(1*DEFAULT_CHUNK_SIZE, 2*DEFAULT_CHUNK_SIZE),
+                        3: slice(2*DEFAULT_CHUNK_SIZE, 3*DEFAULT_CHUNK_SIZE),
         }
         data3_chunks[0][0] = 2.0
         data[0] = 2.0
@@ -92,22 +92,22 @@ def test_create_version_chunks():
         version3 = create_version(f, 'version3', {'test_data':  data3_chunks})
         assert_equal(version3['test_data'], data)
 
-        assert ds.shape == (5*CHUNK_SIZE,)
-        assert_equal(ds[0:1*CHUNK_SIZE], 1.0)
-        assert_equal(ds[1*CHUNK_SIZE:2*CHUNK_SIZE], 2.0)
-        assert_equal(ds[2*CHUNK_SIZE:3*CHUNK_SIZE], 3.0)
-        assert_equal(ds[3*CHUNK_SIZE], 0.0)
-        assert_equal(ds[3*CHUNK_SIZE+1:4*CHUNK_SIZE], 1.0)
-        assert_equal(ds[4*CHUNK_SIZE], 2.0)
-        assert_equal(ds[4*CHUNK_SIZE+1:5*CHUNK_SIZE], 1.0)
+        assert ds.shape == (5*DEFAULT_CHUNK_SIZE,)
+        assert_equal(ds[0:1*DEFAULT_CHUNK_SIZE], 1.0)
+        assert_equal(ds[1*DEFAULT_CHUNK_SIZE:2*DEFAULT_CHUNK_SIZE], 2.0)
+        assert_equal(ds[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE], 3.0)
+        assert_equal(ds[3*DEFAULT_CHUNK_SIZE], 0.0)
+        assert_equal(ds[3*DEFAULT_CHUNK_SIZE+1:4*DEFAULT_CHUNK_SIZE], 1.0)
+        assert_equal(ds[4*DEFAULT_CHUNK_SIZE], 2.0)
+        assert_equal(ds[4*DEFAULT_CHUNK_SIZE+1:5*DEFAULT_CHUNK_SIZE], 1.0)
 
         assert set(all_versions(f)) == {'version1', 'version2', 'version3'}
 
 def test_get_nth_prev_version():
     with setup() as f:
-        data = np.concatenate((np.ones((2*CHUNK_SIZE,)),
-                               2*np.ones((CHUNK_SIZE,)),
-                               3*np.ones((CHUNK_SIZE,))))
+        data = np.concatenate((np.ones((2*DEFAULT_CHUNK_SIZE,)),
+                               2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                               3*np.ones((DEFAULT_CHUNK_SIZE,))))
 
         create_version(f, 'version1', {'test_data': data})
 
@@ -143,9 +143,9 @@ def test_get_nth_prev_version():
 
 def test_set_current_version():
     with setup() as f:
-        data = np.concatenate((np.ones((2*CHUNK_SIZE,)),
-                               2*np.ones((CHUNK_SIZE,)),
-                               3*np.ones((CHUNK_SIZE,))))
+        data = np.concatenate((np.ones((2*DEFAULT_CHUNK_SIZE,)),
+                               2*np.ones((DEFAULT_CHUNK_SIZE,)),
+                               3*np.ones((DEFAULT_CHUNK_SIZE,))))
 
         create_version(f, 'version1', {'test_data': data})
         versions = f['_version_data/versions']

--- a/versioned_hdf5/versions.py
+++ b/versioned_hdf5/versions.py
@@ -4,7 +4,7 @@ from .backend import write_dataset, write_dataset_chunks, create_virtual_dataset
 
 # TODO: Allow version_name to be a version group
 def create_version(f, version_name, datasets, prev_version=None, *,
-                   make_current=True):
+                   make_current=True, chunk_size=None):
     """
     Create a new version
 
@@ -47,9 +47,11 @@ def create_version(f, version_name, datasets, prev_version=None, *,
         if isinstance(data, InMemoryDataset):
             data = data.id.data_dict
         if isinstance(data, dict):
+            if chunk_size is not None:
+                raise NotImplementedError("Specifying chunk size with dict data")
             slices = write_dataset_chunks(f, name, data)
         else:
-            slices = write_dataset(f, name, data)
+            slices = write_dataset(f, name, data, chunk_size=chunk_size)
         create_virtual_dataset(f, version_name, name, slices)
 
     return group

--- a/versioned_hdf5/versions.py
+++ b/versioned_hdf5/versions.py
@@ -41,19 +41,25 @@ def create_version(f, version_name, datasets, prev_version=None, *,
     group = versions.create_group(version_name)
     group.attrs['prev_version'] = prev_version
     if make_current:
+        old_current = versions.attrs['current_version']
         versions.attrs['current_version'] = version_name
 
-    for name, data in datasets.items():
-        if isinstance(data, InMemoryDataset):
-            data = data.id.data_dict
-        if isinstance(data, dict):
-            if chunk_size is not None:
-                raise NotImplementedError("Specifying chunk size with dict data")
-            slices = write_dataset_chunks(f, name, data)
-        else:
-            slices = write_dataset(f, name, data, chunk_size=chunk_size)
-        create_virtual_dataset(f, version_name, name, slices)
-
+    try:
+        for name, data in datasets.items():
+            if isinstance(data, InMemoryDataset):
+                data = data.id.data_dict
+            if isinstance(data, dict):
+                if chunk_size is not None:
+                    raise NotImplementedError("Specifying chunk size with dict data")
+                slices = write_dataset_chunks(f, name, data)
+            else:
+                slices = write_dataset(f, name, data, chunk_size=chunk_size)
+            create_virtual_dataset(f, version_name, name, slices)
+    except Exception:
+        del versions[version_name]
+        if make_current:
+            versions.attrs['current_version'] = old_current
+        raise
     return group
 
 def get_nth_previous_version(f, version_name, n):


### PR DESCRIPTION
There is now a `chunk_size` parameter to `stage_version`. If not specified, the default chunk size of 2**12 is used.

Fixes #4. 