### PR TITLE
Allow setting the compression when creating a dataset

### DIFF
--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -6,6 +6,7 @@ from h5py._hl.vds import VDSmap
 import numpy as np
 
 from contextlib import contextmanager
+from collections import defaultdict
 import datetime
 import math
 
@@ -101,7 +102,7 @@ class VersionedHDF5File:
 
     @contextmanager
     def stage_version(self, version_name: str, prev_version=None,
-                      make_current=True, chunk_size=None):
+                      make_current=True):
         """
         Return a context manager to stage a new version
 
@@ -126,12 +127,17 @@ class VersionedHDF5File:
         yield group
         create_version(self.f, version_name, group.datasets(),
                        prev_version=prev_version, make_current=make_current,
-                       chunk_size=chunk_size)
+                       chunk_size=group.chunk_size,
+                       compression=group.compression,
+                       compression_opts=group.compression_opts)
 
 class InMemoryGroup(Group):
     def __init__(self, bind):
         self._data = {}
         self._subgroups = {}
+        self.chunk_size = defaultdict(type(None))
+        self.compression = defaultdict(type(None))
+        self.compression_opts = defaultdict(type(None))
         super().__init__(bind)
 
     # Based on Group.__repr__
@@ -172,6 +178,16 @@ class InMemoryGroup(Group):
 
     def create_dataset(self, name, **kwds):
         data = super().create_dataset(name, **kwds)
+        chunk_size = kwds.get('chunks')
+        if isinstance(chunk_size, tuple):
+            if len(chunk_size) > 1:
+                raise NotImplementedError("Multiple dimensions")
+            chunk_size = chunk_size[0]
+        if chunk_size is True:
+            raise NotImplementedError("auto-chunking is not yet supported")
+        self.chunk_size[name] = chunk_size
+        self.compression[name] = kwds.get('compression')
+        self.compression_opts[name] = kwds.get('compression_opts')
         self[name] = data
         return data
 

--- a/versioned_hdf5/tests/test_versions.py
+++ b/versioned_hdf5/tests/test_versions.py
@@ -17,9 +17,18 @@ def test_create_version():
                                3*np.ones((chunk_size,))))
 
         version1 = create_version(f, 'version1', {'test_data': data}, '',
-                                  chunk_size=chunk_size)
+                                  chunk_size={'test_data': chunk_size},
+                                  compression={'test_data': 'gzip'},
+                                  compression_opts={'test_data': 3})
         raises(ValueError, lambda: create_version(f, 'version_bad',
-                                  {'test_data': data}, chunk_size=2**9))
+                                  {'test_data': data},
+                                  chunk_size={'test_data': 2**9}))
+        raises(ValueError, lambda: create_version(f, 'version_bad',
+                                  {'test_data': data},
+                                  compression={'test_data': 'lzf'}))
+        raises(ValueError, lambda: create_version(f, 'version_bad',
+                                  {'test_data': data},
+                                  compression_opts={'test_data': 4}))
         assert version1.attrs['prev_version'] == '__first_version__'
         assert version1.parent.attrs['current_version'] == 'version1'
         assert_equal(version1['test_data'], data)
@@ -30,6 +39,8 @@ def test_create_version():
         assert_equal(ds[0:1*chunk_size], 1.0)
         assert_equal(ds[1*chunk_size:2*chunk_size], 2.0)
         assert_equal(ds[2*chunk_size:3*chunk_size], 3.0)
+        assert ds.compression == 'gzip'
+        assert ds.compression_opts == 3
 
         data[0] = 0.0
         version2 = create_version(f, 'version2', {'test_data':
@@ -44,6 +55,8 @@ def test_create_version():
         assert_equal(ds[2*chunk_size:3*chunk_size], 3.0)
         assert_equal(ds[3*chunk_size], 0.0)
         assert_equal(ds[3*chunk_size+1:4*chunk_size], 1.0)
+        assert ds.compression == 'gzip'
+        assert ds.compression_opts == 3
 
         assert set(all_versions(f)) == {'version1', 'version2'}
         assert set(all_versions(f, include_first=True)) == {'version1',
@@ -58,9 +71,18 @@ def test_create_version_chunks():
                                3*np.ones((chunk_size,))))
         # TODO: Support creating the initial version with chunks
         version1 = create_version(f, 'version1', {'test_data': data},
-                                  chunk_size=chunk_size)
+                                  chunk_size={'test_data': chunk_size},
+                                  compression={'test_data': 'gzip'},
+                                  compression_opts={'test_data': 3})
         raises(ValueError, lambda: create_version(f, 'version_bad',
-                                  {'test_data': data}, chunk_size=2**9))
+                                                  {'test_data': data},
+                                                  chunk_size={'test_data':2**9}))
+        raises(ValueError, lambda: create_version(f, 'version_bad',
+                                                  {'test_data': data},
+                                                  compression={'test_data':'lzf'}))
+        raises(ValueError, lambda: create_version(f, 'version_bad',
+                                                  {'test_data': data},
+                                                  compression_opts={'test_data':4}))
         assert_equal(version1['test_data'], data)
 
         ds = f['/_version_data/test_data/raw_data']
@@ -69,6 +91,8 @@ def test_create_version_chunks():
         assert_equal(ds[0:1*chunk_size], 1.0)
         assert_equal(ds[1*chunk_size:2*chunk_size], 2.0)
         assert_equal(ds[2*chunk_size:3*chunk_size], 3.0)
+        assert ds.compression == 'gzip'
+        assert ds.compression_opts == 3
 
         data2_chunks = {0: np.ones((chunk_size,)),
                         1: np.ones((chunk_size,)),
@@ -87,6 +111,8 @@ def test_create_version_chunks():
         assert_equal(ds[2*chunk_size:3*chunk_size], 3.0)
         assert_equal(ds[3*chunk_size], 0.0)
         assert_equal(ds[3*chunk_size+1:4*chunk_size], 1.0)
+        assert ds.compression == 'gzip'
+        assert ds.compression_opts == 3
 
 
         data3_chunks = {0: np.ones((chunk_size,)),


### PR DESCRIPTION
This also removes the chunk_size parameter from stage_version(). This was the
wrong API, because the chunk size should be per-dataset, not per-version. To
set a chunk size now, set the chunks flag when calling create_dataset(), just
as you would with normal h5py.

@melissawm note the change in the API to set the chunk size here. 