### PR TITLE
Fix creation of datasets

### DIFF
--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -180,8 +180,7 @@ class InMemoryGroup(Group):
 
     def __delitem__(self, name):
         if name in self._data:
-            del self._data
-        super().__delitem__(name)
+            del self._data[name]
 
     def create_group(self, name, track_order=None):
         g = super().create_group(name, track_order=track_order)

--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -258,17 +258,17 @@ def make_new_dset(shape=None, dtype=None, data=None, chunks=None,
 
     if isinstance(maxshape, int):
         maxshape = (maxshape,)
-    tmp_shape = maxshape if maxshape is not None else shape
+    # tmp_shape = maxshape if maxshape is not None else shape
 
     # Validate chunk shape
     if isinstance(chunks, int) and not isinstance(chunks, bool):
         chunks = (chunks,)
-    if isinstance(chunks, tuple) and any(
-        chunk > dim for dim, chunk in zip(tmp_shape, chunks) if dim is not None
-    ):
-        errmsg = "Chunk shape must not be greater than data shape in any dimension. "\
-                 "{} is not compatible with {}".format(chunks, shape)
-        raise ValueError(errmsg)
+    # if isinstance(chunks, tuple) and any(
+    #     chunk > dim for dim, chunk in zip(tmp_shape, chunks) if dim is not None
+    # ):
+    #     errmsg = "Chunk shape must not be greater than data shape in any dimension. "\
+    #              "{} is not compatible with {}".format(chunks, shape)
+    #     raise ValueError(errmsg)
 
     if isinstance(dtype, Datatype):
         # Named types are used as-is

--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -257,17 +257,13 @@ def make_new_dset(shape=None, dtype=None, data=None, chunks=None,
 
     if isinstance(maxshape, int):
         maxshape = (maxshape,)
-    # tmp_shape = maxshape if maxshape is not None else shape
 
     # Validate chunk shape
     if isinstance(chunks, int) and not isinstance(chunks, bool):
         chunks = (chunks,)
-    # if isinstance(chunks, tuple) and any(
-    #     chunk > dim for dim, chunk in zip(tmp_shape, chunks) if dim is not None
-    # ):
-    #     errmsg = "Chunk shape must not be greater than data shape in any dimension. "\
-    #              "{} is not compatible with {}".format(chunks, shape)
-    #     raise ValueError(errmsg)
+    # The original make_new_dset errors here if the shape is less than the
+    # chunk size, but we avoid doing that as we cannot change the chunk size
+    # for a dataset for any version once it is created. See #34.
 
     if isinstance(dtype, Datatype):
         # Named types are used as-is

--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -14,7 +14,7 @@ import datetime
 import math
 
 from .backend import initialize
-from .versions import (create_version_group, create_version,
+from .versions import (create_version_group, commit_version,
                        get_nth_previous_version, set_current_version,
                        all_versions)
 from .slicetools import s2t, slice_size, split_slice
@@ -130,7 +130,7 @@ class VersionedHDF5File:
         group = create_version_group(self.f, version_name,
                                      prev_version=prev_version)
         yield group
-        create_version(group, group.datasets(), make_current=make_current,
+        commit_version(group, group.datasets(), make_current=make_current,
                        chunk_size=group.chunk_size,
                        compression=group.compression,
                        compression_opts=group.compression_opts)

--- a/versioned_hdf5/tests/test_versions.py
+++ b/versioned_hdf5/tests/test_versions.py
@@ -6,8 +6,9 @@ from numpy.testing import assert_equal
 from .test_backend import setup
 
 from ..backend import DEFAULT_CHUNK_SIZE
-from ..versions import (create_version, get_nth_previous_version,
-                        set_current_version, all_versions)
+from ..versions import (create_version_group, commit_version,
+                        get_nth_previous_version, set_current_version,
+                        all_versions)
 
 def test_create_version():
     with setup() as f:
@@ -16,22 +17,27 @@ def test_create_version():
                                2*np.ones((chunk_size,)),
                                3*np.ones((chunk_size,))))
 
-        version1 = create_version(f, 'version1', {'test_data': data}, '',
-                                  chunk_size={'test_data': chunk_size},
-                                  compression={'test_data': 'gzip'},
-                                  compression_opts={'test_data': 3})
-        raises(ValueError, lambda: create_version(f, 'version_bad',
-                                  {'test_data': data},
-                                  chunk_size={'test_data': 2**9}))
-        raises(ValueError, lambda: create_version(f, 'version_bad',
-                                  {'test_data': data},
-                                  compression={'test_data': 'lzf'}))
-        raises(ValueError, lambda: create_version(f, 'version_bad',
-                                  {'test_data': data},
-                                  compression_opts={'test_data': 4}))
+        version1 = create_version_group(f, 'version1', '')
+        commit_version(version1, {'test_data': data},
+                       chunk_size={'test_data': chunk_size},
+                       compression={'test_data': 'gzip'},
+                       compression_opts={'test_data': 3})
+        version_bad = create_version_group(f, 'version_bad', '')
+        raises(ValueError, lambda: commit_version(version_bad, {'test_data': data},
+                                                  chunk_size={'test_data': 2**9}))
+        version_bad = create_version_group(f, 'version_bad', '')
+        raises(ValueError, lambda: commit_version(version_bad, {'test_data': data},
+                                                  compression={'test_data': 'lzf'}))
+        version_bad = create_version_group(f, 'version_bad', '')
+        raises(ValueError, lambda: commit_version(version_bad,
+                                                        {'test_data': data},
+                                                        compression_opts={'test_data': 4}))
         assert version1.attrs['prev_version'] == '__first_version__'
         assert version1.parent.attrs['current_version'] == 'version1'
-        assert_equal(version1['test_data'], data)
+        # Test against the file here, not version1, since version1 is the
+        # InMemoryGroup returned from create_version_group, but we did not add
+        # the datasets to it directly.
+        assert_equal(f['_version_data/versions/version1/test_data'], data)
 
         ds = f['/_version_data/test_data/raw_data']
 
@@ -43,10 +49,15 @@ def test_create_version():
         assert ds.compression_opts == 3
 
         data[0] = 0.0
-        version2 = create_version(f, 'version2', {'test_data':
-        data}, 'version1', make_current=False)
+        version2 = create_version_group(f, 'version2', 'version1')
+
+        raises(ValueError,
+               lambda: commit_version(version1, {'test_data': data},
+                                      make_current=False))
+        commit_version(version2, {'test_data': data},
+                       make_current=False)
         assert version2.attrs['prev_version'] == 'version1'
-        assert_equal(version2['test_data'], data)
+        assert_equal(f['_version_data/versions/version2/test_data'], data)
         assert version2.parent.attrs['current_version'] == 'version1'
 
         assert ds.shape == (4*chunk_size,)
@@ -70,20 +81,24 @@ def test_create_version_chunks():
                                2*np.ones((chunk_size,)),
                                3*np.ones((chunk_size,))))
         # TODO: Support creating the initial version with chunks
-        version1 = create_version(f, 'version1', {'test_data': data},
-                                  chunk_size={'test_data': chunk_size},
-                                  compression={'test_data': 'gzip'},
-                                  compression_opts={'test_data': 3})
-        raises(ValueError, lambda: create_version(f, 'version_bad',
+        version1 = create_version_group(f, 'version1')
+        commit_version(version1, {'test_data': data},
+                       chunk_size={'test_data': chunk_size},
+                       compression={'test_data': 'gzip'},
+                       compression_opts={'test_data': 3})
+        version_bad = create_version_group(f, 'version_bad', '')
+        raises(ValueError, lambda: commit_version(version_bad,
                                                   {'test_data': data},
                                                   chunk_size={'test_data':2**9}))
-        raises(ValueError, lambda: create_version(f, 'version_bad',
+        version_bad = create_version_group(f, 'version_bad', '')
+        raises(ValueError, lambda: commit_version(version_bad,
                                                   {'test_data': data},
                                                   compression={'test_data':'lzf'}))
-        raises(ValueError, lambda: create_version(f, 'version_bad',
+        version_bad = create_version_group(f, 'version_bad', '')
+        raises(ValueError, lambda: commit_version(version_bad,
                                                   {'test_data': data},
                                                   compression_opts={'test_data':4}))
-        assert_equal(version1['test_data'], data)
+        assert_equal(f['_version_data/versions/version1/test_data'], data)
 
         ds = f['/_version_data/test_data/raw_data']
 
@@ -102,8 +117,9 @@ def test_create_version_chunks():
         data2_chunks[0][0] = 0.0
         data[0] = 0.0
 
-        version2 = create_version(f, 'version2', {'test_data':  data2_chunks})
-        assert_equal(version2['test_data'], data)
+        version2 = create_version_group(f, 'version2')
+        commit_version(version2, {'test_data':  data2_chunks})
+        assert_equal(f['_version_data/versions/version2/test_data'], data)
 
         assert ds.shape == (4*chunk_size,)
         assert_equal(ds[0:1*chunk_size], 1.0)
@@ -123,8 +139,9 @@ def test_create_version_chunks():
         data3_chunks[0][0] = 2.0
         data[0] = 2.0
 
-        version3 = create_version(f, 'version3', {'test_data':  data3_chunks})
-        assert_equal(version3['test_data'], data)
+        version3 = create_version_group(f, 'version3')
+        commit_version(version3, {'test_data':  data3_chunks})
+        assert_equal(f['_version_data/versions/version3/test_data'], data)
 
         assert ds.shape == (5*chunk_size,)
         assert_equal(ds[0:1*chunk_size], 1.0)
@@ -143,16 +160,20 @@ def test_get_nth_prev_version():
                                2*np.ones((DEFAULT_CHUNK_SIZE,)),
                                3*np.ones((DEFAULT_CHUNK_SIZE,))))
 
-        create_version(f, 'version1', {'test_data': data})
+        version1 = create_version_group(f, 'version1')
+        commit_version(version1, {'test_data': data})
 
         data[0] = 2.0
-        create_version(f, 'version2', {'test_data': data})
+        version2 = create_version_group(f, 'version2')
+        commit_version(version2, {'test_data': data})
 
         data[0] = 3.0
-        create_version(f, 'version3', {'test_data': data})
+        version3 = create_version_group(f, 'version3')
+        commit_version(version3, {'test_data': data})
 
         data[1] = 2.0
-        create_version(f, 'version2_1', {'test_data': data}, 'version1')
+        version2_1 = create_version_group(f, 'version2_1', 'version1')
+        commit_version(version2_1, {'test_data': data})
 
         assert get_nth_previous_version(f, 'version1', 0) == 'version1'
 
@@ -181,12 +202,14 @@ def test_set_current_version():
                                2*np.ones((DEFAULT_CHUNK_SIZE,)),
                                3*np.ones((DEFAULT_CHUNK_SIZE,))))
 
-        create_version(f, 'version1', {'test_data': data})
+        version1 = create_version_group(f, 'version1')
+        commit_version(version1, {'test_data': data})
         versions = f['_version_data/versions']
         assert versions.attrs['current_version'] == 'version1'
 
         data[0] = 2.0
-        create_version(f, 'version2', {'test_data': data})
+        version2 = create_version_group(f, 'version2')
+        commit_version(version2, {'test_data': data})
         assert versions.attrs['current_version'] == 'version2'
 
         set_current_version(f, 'version1')

--- a/versioned_hdf5/versions.py
+++ b/versioned_hdf5/versions.py
@@ -33,7 +33,7 @@ def create_version_group(f, version_name, prev_version=None):
     prev_group.visititems(_get)
     return group
 
-def create_version(version_group, datasets, *,
+def commit_version(version_group, datasets, *,
                    make_current=True, chunk_size=None,
                    compression=None, compression_opts=None):
     """
@@ -84,7 +84,6 @@ def create_version(version_group, datasets, *,
         if make_current:
             versions.attrs['current_version'] = old_current
         raise
-    return version_group
 
 def get_nth_previous_version(f, version_name, n):
     versions = f['_version_data/versions']


### PR DESCRIPTION
Prior to this, datasets are created in the group of the previous version. But
this actually corrupts the previous version if any new datasets are created.
Instead, we should copy everything over from the previous version. It also
means we shouldn't actually call create_dataset() on the h5py Group object,
but rather fake it so that it goes through our machinery.

This isn't completely fixed yet. There are still some bugs, and we need to
handle groups properly. There are also some tests that need to be fixed, as
well as new tests that need to be written.

This will eventually fix #32 and fix #34.