### PR TITLE
Fix resize computation when last chunk does not align with chunk_size

### DIFF
--- a/versioned_hdf5/api.py
+++ b/versioned_hdf5/api.py
@@ -279,7 +279,7 @@ class InMemoryDatasetID(h5d.DatasetID):
                     a = data_dict[i]
                 assert a.shape[0] == old_shape % chunk_size
                 if i == quo:
-                    data_dict[i] = np.concatenate([a, np.zeros((shape[0] -
+                    data_dict[i] = np.concatenate([a, np.zeros((rem -
                         a.shape[0]), dtype=self.dtype)])
                 else:
                     data_dict[i] = np.concatenate([a, np.zeros((chunk_size -

--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -474,6 +474,23 @@ def test_resize():
         group = file['version2_small']
         assert_equal(group['small'], np.array([1, 2, 3, 4, 5]))
 
+
+def test_resize_unaligned():
+    with setup() as f:
+        file = VersionedHDF5File(f)
+        ds_name = 'test_resize_unaligned'
+        with file.stage_version('0') as group:
+            group.create_dataset(ds_name, data=np.arange(1000))
+
+        for i in range(1, 10):
+            with file.stage_version(str(i)) as group:
+                l = len(group[ds_name])
+                assert_equal(group[ds_name][:], np.arange(i * 1000))
+                group[ds_name].resize((l + 1000,))
+                group[ds_name][-1000:] = np.arange(l, l + 1000)
+                assert_equal(group[ds_name][:], np.arange((i + 1) * 1000))
+
+
 def test_getitem():
     with setup() as f:
         file = VersionedHDF5File(f)


### PR DESCRIPTION
Before this change the current resize logic is incorrectly resizing the
array in data_dict by concatenating with an all zero array of the full
length instead of just the remainder in the last chunk.

This fixes https://github.com/Quansight/versioned-hdf5/issues/35