### PR TITLE
Fix reading from hdf5 files that have been moved

### DIFF
--- a/versioned_hdf5/backend.py
+++ b/versioned_hdf5/backend.py
@@ -130,7 +130,7 @@ def create_virtual_dataset(f, version_name, name, slices, attrs=None):
     shape = (chunk_size*(len(slices) - 1) + slices[-1].stop - slices[-1].start,)
 
     layout = VirtualLayout(shape, dtype=raw_data.dtype)
-    vs = VirtualSource(raw_data)
+    vs = VirtualSource('.', name=raw_data.name, shape=raw_data.shape, dtype=raw_data.dtype)
 
     for i, s in enumerate(slices):
         # TODO: This needs to handle more than one dimension

--- a/versioned_hdf5/tests/helpers.py
+++ b/versioned_hdf5/tests/helpers.py
@@ -3,9 +3,9 @@ import h5py
 from ..backend import initialize
 
 # TODO: Use a fixture for this
-def setup(name=None, version_name=None):
+def setup(file_name='test.hdf5', name=None, version_name=None):
     # TODO: Use a temporary directory
-    f = h5py.File('test.hdf5', 'w')
+    f = h5py.File(file_name, 'w')
     initialize(f)
     if name:
         f['_version_data'].create_group(name)

--- a/versioned_hdf5/tests/test_backend.py
+++ b/versioned_hdf5/tests/test_backend.py
@@ -116,7 +116,6 @@ def test_create_virtual_dataset_offset():
         assert_equal(virtual_data[0:2*DEFAULT_CHUNK_SIZE], 1.0)
         assert_equal(virtual_data[2*DEFAULT_CHUNK_SIZE:3*DEFAULT_CHUNK_SIZE - 2], 3.0)
 
-
 def test_write_dataset_chunk_size():
     with setup() as f:
         chunk_size = 2**10


### PR DESCRIPTION
h5py by default hard-codes the filename as the virtual data source, meaning if
the file is renamed, it won't be able to find the virtual source, and will
give all 0s (because it masks the error from HDF5). If we instead pass the
undocumented string "." as the file name, it references the current file and
works after renaming.

Fixes #28.