### PR TITLE
Add support for fill values

### DIFF
--- a/versioned_hdf5/tests/test_api.py
+++ b/versioned_hdf5/tests/test_api.py
@@ -278,7 +278,7 @@ def test_changes_dataset():
     test_data = np.ones((2*DEFAULT_CHUNK_SIZE,))
 
     name = "testname"
-    
+
     with setup() as f:
         file = VersionedHDF5File(f)
 
@@ -290,7 +290,7 @@ def test_changes_dataset():
         assert version1.attrs['prev_version'] == '__first_version__'
         assert_equal(version1[f'{name}/key'], test_data)
         assert_equal(version1[f'{name}/val'], test_data)
-            
+
         with file.stage_version('version2') as group:
             key_ds = group[f'{name}/key']
             val_ds = group[f'{name}/val']
@@ -311,7 +311,7 @@ def test_changes_dataset():
         assert list(f['_version_data/versions/version1']) == list(file['version1']) == [name]
         assert list(f['_version_data/versions/version2']) == list(file['version2']) == [name]
 
-        
+
 def test_small_dataset():
     # Test creating a dataset that is smaller than the chunk size
     with setup() as f:
@@ -820,7 +820,7 @@ def test_moved_file():
         file = VersionedHDF5File(f)
 
         data = np.ones(2*DEFAULT_CHUNK_SIZE)
-        
+
         with file.stage_version('version1') as group:
             group['dataset'] = data
 
@@ -843,8 +843,108 @@ def test_list_assign():
 
         with file.stage_version('version1') as group:
             group['dataset'] = data
-    
+
             assert_equal(group['dataset'][:], data)
 
         assert_equal(file['version1']['dataset'][:], data)
 
+def test_fillvalue():
+    # Based on test_resize(), but only the resize largers that use the fill
+    # value
+    with setup() as f:
+        file = VersionedHDF5File(f)
+
+        fillvalue = 5.0
+
+        no_offset_data = np.ones((2*DEFAULT_CHUNK_SIZE,))
+
+        offset_data = np.concatenate((np.ones((DEFAULT_CHUNK_SIZE,)),
+                                      np.ones((2,))))
+
+        with file.stage_version('version1') as group:
+            group.create_dataset('no_offset', data=no_offset_data, fillvalue=fillvalue)
+            group.create_dataset('offset', data=offset_data, fillvalue=fillvalue)
+
+        group = file['version1']
+        assert group['no_offset'].shape == (2*DEFAULT_CHUNK_SIZE,)
+        assert group['offset'].shape == (DEFAULT_CHUNK_SIZE + 2,)
+        assert_equal(group['no_offset'][:2*DEFAULT_CHUNK_SIZE], 1.0)
+        assert_equal(group['offset'][:DEFAULT_CHUNK_SIZE + 2], 1.0)
+
+        # Resize larger, chunk multiple
+        with file.stage_version('larger_chunk_multiple') as group:
+            group['no_offset'].resize((3*DEFAULT_CHUNK_SIZE,))
+            group['offset'].resize((3*DEFAULT_CHUNK_SIZE,))
+
+        group = file['larger_chunk_multiple']
+        assert group['no_offset'].shape == (3*DEFAULT_CHUNK_SIZE,)
+        assert group['offset'].shape == (3*DEFAULT_CHUNK_SIZE,)
+        assert_equal(group['no_offset'][:2*DEFAULT_CHUNK_SIZE], 1.0)
+        assert_equal(group['no_offset'][2*DEFAULT_CHUNK_SIZE:], fillvalue)
+        assert_equal(group['offset'][:DEFAULT_CHUNK_SIZE + 2], 1.0)
+        assert_equal(group['offset'][DEFAULT_CHUNK_SIZE + 2:], fillvalue)
+
+
+        # Resize larger, non-chunk multiple
+        with file.stage_version('larger_chunk_non_multiple', 'version1') as group:
+            group['no_offset'].resize((3*DEFAULT_CHUNK_SIZE + 2,))
+            group['offset'].resize((3*DEFAULT_CHUNK_SIZE + 2,))
+
+        group = file['larger_chunk_non_multiple']
+        assert group['no_offset'].shape == (3*DEFAULT_CHUNK_SIZE + 2,)
+        assert group['offset'].shape == (3*DEFAULT_CHUNK_SIZE + 2,)
+        assert_equal(group['no_offset'][:2*DEFAULT_CHUNK_SIZE], 1.0)
+        assert_equal(group['no_offset'][2*DEFAULT_CHUNK_SIZE:], fillvalue)
+        assert_equal(group['offset'][:DEFAULT_CHUNK_SIZE + 2], 1.0)
+        assert_equal(group['offset'][DEFAULT_CHUNK_SIZE + 2:], fillvalue)
+
+        # Resize after creation
+        with file.stage_version('version2', 'version1') as group:
+            # Cover the case where some data is already read in
+            group['offset'][-1] = 2.0
+
+            group['no_offset'].resize((3*DEFAULT_CHUNK_SIZE + 2,))
+            group['offset'].resize((3*DEFAULT_CHUNK_SIZE + 2,))
+
+            assert group['no_offset'].shape == (3*DEFAULT_CHUNK_SIZE + 2,)
+            assert group['offset'].shape == (3*DEFAULT_CHUNK_SIZE + 2,)
+            assert_equal(group['no_offset'][:2*DEFAULT_CHUNK_SIZE], 1.0)
+            assert_equal(group['no_offset'][2*DEFAULT_CHUNK_SIZE:], fillvalue)
+            assert_equal(group['offset'][:DEFAULT_CHUNK_SIZE + 1], 1.0)
+            assert_equal(group['offset'][DEFAULT_CHUNK_SIZE + 1], 2.0)
+            assert_equal(group['offset'][DEFAULT_CHUNK_SIZE + 2:], fillvalue)
+
+            group['no_offset'].resize((3*DEFAULT_CHUNK_SIZE,))
+            group['offset'].resize((3*DEFAULT_CHUNK_SIZE,))
+
+            assert group['no_offset'].shape == (3*DEFAULT_CHUNK_SIZE,)
+            assert group['offset'].shape == (3*DEFAULT_CHUNK_SIZE,)
+            assert_equal(group['no_offset'][:2*DEFAULT_CHUNK_SIZE], 1.0)
+            assert_equal(group['no_offset'][2*DEFAULT_CHUNK_SIZE:], fillvalue)
+            assert_equal(group['offset'][:DEFAULT_CHUNK_SIZE + 1], 1.0)
+            assert_equal(group['offset'][DEFAULT_CHUNK_SIZE + 1], 2.0)
+            assert_equal(group['offset'][DEFAULT_CHUNK_SIZE + 2:], fillvalue)
+
+        group = file['version2']
+        assert group['no_offset'].shape == (3*DEFAULT_CHUNK_SIZE,)
+        assert group['offset'].shape == (3*DEFAULT_CHUNK_SIZE,)
+        assert_equal(group['no_offset'][:2*DEFAULT_CHUNK_SIZE], 1.0)
+        assert_equal(group['no_offset'][2*DEFAULT_CHUNK_SIZE:], fillvalue)
+        assert_equal(group['offset'][:DEFAULT_CHUNK_SIZE + 1], 1.0)
+        assert_equal(group['offset'][DEFAULT_CHUNK_SIZE + 1], 2.0)
+        assert_equal(group['offset'][DEFAULT_CHUNK_SIZE + 2:], fillvalue)
+
+        # Resize after calling create_dataset, larger
+        with file.stage_version('resize_after_create_larger', '') as group:
+            group.create_dataset('data', data=offset_data,
+                                 fillvalue=fillvalue)
+            group['data'].resize((DEFAULT_CHUNK_SIZE + 4,))
+
+            assert group['data'].shape == (DEFAULT_CHUNK_SIZE + 4,)
+            assert_equal(group['data'][:DEFAULT_CHUNK_SIZE + 2], 1.0)
+            assert_equal(group['data'][DEFAULT_CHUNK_SIZE + 2:], fillvalue)
+
+        group = file['resize_after_create_larger']
+        assert group['data'].shape == (DEFAULT_CHUNK_SIZE + 4,)
+        assert_equal(group['data'][:DEFAULT_CHUNK_SIZE + 2], 1.0)
+        assert_equal(group['data'][DEFAULT_CHUNK_SIZE + 2:], fillvalue)

--- a/versioned_hdf5/versions.py
+++ b/versioned_hdf5/versions.py
@@ -70,8 +70,10 @@ def commit_version(version_group, datasets, *,
         versions.attrs['current_version'] = version_name
 
     for name, data in datasets.items():
+        fillvalue = None
         if isinstance(data, (InMemoryDataset, InMemoryArrayDataset)):
             attrs = data.attrs
+            fillvalue = data.fillvalue
         else:
             attrs = {}
 
@@ -82,10 +84,12 @@ def commit_version(version_group, datasets, *,
                 raise NotImplementedError("Specifying chunk size with dict data")
             slices = write_dataset_chunks(f, name, data)
         else:
-            slices = write_dataset(f, name, data,
-                                   chunk_size=chunk_size[name], compression=compression[name],
-                                   compression_opts=compression_opts[name])
-        create_virtual_dataset(f, version_name, name, slices, attrs=attrs)
+            slices = write_dataset(f, name, data, chunk_size=chunk_size[name],
+                                   compression=compression[name],
+                                   compression_opts=compression_opts[name],
+                                   fillvalue=fillvalue)
+        create_virtual_dataset(f, version_name, name, slices, attrs=attrs,
+                               fillvalue=fillvalue)
     version_group.attrs['committed'] = True
 
 def delete_version(f, version_name, new_current=None):

--- a/versioned_hdf5/wrappers.py
+++ b/versioned_hdf5/wrappers.py
@@ -92,6 +92,8 @@ class InMemoryGroup(Group):
             self._subgroups[name] = InMemoryGroup(obj.id)
         elif isinstance(obj, InMemoryGroup):
             self._subgroups[name] = obj
+        elif isinstance(obj, InMemoryArrayDataset):
+            self._data[name] = obj
         else:
             self._data[name] = InMemoryArrayDataset(name, np.asarray(obj))
 
@@ -133,6 +135,8 @@ class InMemoryGroup(Group):
         if dirname and dirname not in self:
             self.create_group(dirname)
         data = _make_new_dset(**kwds)
+        if 'fillvalue' in kwds:
+            data = InMemoryArrayDataset(name, data, fillvalue=kwds['fillvalue'])
         chunk_size = kwds.get('chunks')
         if isinstance(chunk_size, tuple):
             if len(chunk_size) > 1:
@@ -314,10 +318,11 @@ class InMemoryArrayDataset:
     """
     Class that looks like a h5py.Dataset but is backed by an array
     """
-    def __init__(self, name, array):
+    def __init__(self, name, array, fillvalue=None):
         self.name = name
         self._array = array
         self.attrs = {}
+        self.fillvalue = fillvalue or array.dtype.type()
 
     @property
     def array(self):
@@ -393,9 +398,9 @@ class InMemoryArrayDataset:
         if len(size) > 1:
             raise NotImplementedError("More than one dimension is not yet supported")
         if size[0] > self.shape[0]:
-            self.array = np.concatenate((self.array,
-                                         np.zeros(size[0] - self.shape[0],
-                                                  dtype=self.dtype)))
+            self.array = np.concatenate((self.array, np.full(size[0] -
+                                                             self.shape[0], self.fillvalue,
+                                                             dtype=self.dtype)))
         else:
             self.array = self.array[:size[0]]
 
@@ -429,6 +434,10 @@ class InMemoryDatasetID(h5d.DatasetID):
         for s in slice_map:
             self.data_dict[s.start//self.chunk_size] = slice_map[s]
 
+        fillvalue_a = np.empty((1,), dtype=self.dtype)
+        dcpl.get_fill_value(fillvalue_a)
+        self.fillvalue = fillvalue_a[0]
+
     def set_extent(self, shape):
         if len(shape) > 1:
             raise NotImplementedError("More than one dimension is not yet supported")
@@ -458,17 +467,17 @@ class InMemoryDatasetID(h5d.DatasetID):
                     a = data_dict[i]
                 assert a.shape[0] == old_shape % chunk_size
                 if i == quo:
-                    data_dict[i] = np.concatenate([a, np.zeros((rem -
-                        a.shape[0]), dtype=self.dtype)])
+                    data_dict[i] = np.concatenate([a, np.full((rem -
+                        a.shape[0]), self.fillvalue, dtype=self.dtype)])
                 else:
-                    data_dict[i] = np.concatenate([a, np.zeros((chunk_size -
-                        a.shape[0],), dtype=self.dtype)])
+                    data_dict[i] = np.concatenate([a, np.full((chunk_size -
+                        a.shape[0],), self.fillvalue, dtype=self.dtype)])
             if rem != 0 and quo not in data_dict:
-                # Zeros along the chunks are added in the for loop below, but
-                # we have to add a sub-chunk zeros here
-                data_dict[quo] = np.zeros((rem,), dtype=self.dtype)
+                # fillvalue along the chunks are added in the for loop below,
+                # but we have to add a sub-chunk fillvalues here
+                data_dict[quo] = np.full((rem,), self.fillvalue, dtype=self.dtype)
             for i in range(math.ceil(old_shape[0]/chunk_size), quo):
-                data_dict[i] = np.zeros((chunk_size,), dtype=self.dtype)
+                data_dict[i] = np.full((chunk_size,), self.fillvalue, dtype=self.dtype)
         self.shape = shape
 
     @property


### PR DESCRIPTION
We still don't support empty datasets, so the fill value only affects resizes.

Fixes partially #60